### PR TITLE
Fix CSRF vulnerability (CVE-2025-47909)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module github.com/Chuntttttt/tapedeck
 go 1.25
 
 require (
+	filippo.io/csrf v0.2.1
 	github.com/a-h/templ v0.3.943
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/csrf v1.7.3
 	github.com/gorilla/sessions v1.4.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
+	github.com/jung-kurt/gofpdf v1.16.2
 	github.com/prometheus/client_golang v1.23.2
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.39.1
@@ -23,7 +24,6 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/jung-kurt/gofpdf v1.16.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/csrf v0.2.1 h1:MdV/y9xOECwJko48lPkH9NaYNpZ6kYfaNlgnZk4k6Uo=
+filippo.io/csrf v0.2.1/go.mod h1:eVfdeENlqr/ErpNx4E5I6a11I1aP0WL/PPkzKD1d960=
 github.com/a-h/templ v0.3.943 h1:o+mT/4yqhZ33F3ootBiHwaY4HM5EVaOJfIshvd5UNTY=
 github.com/a-h/templ v0.3.943/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -23,8 +25,6 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
-github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=

--- a/internal/handlers/mappings.go
+++ b/internal/handlers/mappings.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/sticker"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
 	"github.com/go-chi/chi/v5"
-	"github.com/gorilla/csrf"
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/gorilla/sessions"
 )
 

--- a/internal/handlers/media_detail.go
+++ b/internal/handlers/media_detail.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/plex"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
 	"github.com/go-chi/chi/v5"
-	"github.com/gorilla/csrf"
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/gorilla/sessions"
 )
 

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/db"
 	"github.com/Chuntttttt/tapedeck/internal/middleware"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
-	"github.com/gorilla/csrf"
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/gorilla/sessions"
 )
 

--- a/internal/handlers/setup.go
+++ b/internal/handlers/setup.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/models"
 	"github.com/Chuntttttt/tapedeck/internal/plex"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
-	"github.com/gorilla/csrf"
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/gorilla/sessions"
 )
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/Chuntttttt/tapedeck/internal/config"
 	"github.com/Chuntttttt/tapedeck/internal/constants"
 	"github.com/Chuntttttt/tapedeck/internal/db"
@@ -23,7 +24,6 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/router"
 	"github.com/Chuntttttt/tapedeck/internal/services"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
-	"github.com/gorilla/csrf"
 )
 
 // csrfExemptMiddleware wraps CSRF protection but exempts certain routes
@@ -346,11 +346,9 @@ func main() {
 	r := router.New(deps)
 
 	// Configure CSRF protection
-	// Exempt API and WebSocket routes (they use JSON/WebSocket, not forms)
+	// Note: filippo.io/csrf uses Fetch metadata headers (Sec-Fetch-Site, Origin)
+	// instead of cookies and tokens for CSRF protection
 	csrfOptions := []csrf.Option{
-		csrf.Secure(cfg.RequireTLS),
-		csrf.Path("/"),
-		csrf.SameSite(csrf.SameSiteLaxMode),
 		csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger.Warn("CSRF validation failed",
 				"path", r.URL.Path,
@@ -363,9 +361,9 @@ func main() {
 			// Render proper error page
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusForbidden)
-			if err := pages.Error(http.StatusForbidden, "CSRF token validation failed. Please try again.").Render(r.Context(), w); err != nil {
+			if err := pages.Error(http.StatusForbidden, "CSRF validation failed. Please try again.").Render(r.Context(), w); err != nil {
 				logger.Error("Failed to render CSRF error page", "error", err)
-				http.Error(w, "CSRF token validation failed", http.StatusForbidden)
+				http.Error(w, "CSRF validation failed", http.StatusForbidden)
 			}
 		})),
 	}


### PR DESCRIPTION
## Summary
Fixes CVE-2025-47909 - CSRF vulnerability in github.com/gorilla/csrf where TrustedOrigins improperly validates hosts, allowing network MitM attacks.

## Changes
- Replace `github.com/gorilla/csrf` with drop-in replacement `filippo.io/csrf/gorilla`
- Remove deprecated CSRF options (Secure, Path, SameSite) - no longer used by new implementation
- Update error messages from "token validation" to "validation" 
- New package uses Fetch metadata headers (Sec-Fetch-Site, Origin) instead of cookies/tokens

## Security Impact
- **Severity**: Medium
- **CVE**: CVE-2025-47909
- **Fix**: Same-origin enforcement without cookies/tokens
- **Compatibility**: Drop-in replacement, all tests passing

## Testing
- ✅ All unit tests passing
- ✅ Build successful
- ✅ Backward compatible (Token() calls remain for template compatibility)

Resolves #1 (Dependabot alert)