### PR TITLE
Fix CVE-2025-47909: Replace gorilla/csrf with Go 1.25 CrossOriginProtection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/csrf v1.7.3
 	github.com/gorilla/sessions v1.4.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
+	github.com/jung-kurt/gofpdf v1.16.2
 	github.com/prometheus/client_golang v1.23.2
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.39.1
@@ -23,7 +23,6 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/jung-kurt/gofpdf v1.16.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
-github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=

--- a/internal/handlers/mappings.go
+++ b/internal/handlers/mappings.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/sticker"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
 	"github.com/go-chi/chi/v5"
-	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
 )
 
@@ -113,7 +112,7 @@ func (h *MappingsHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	h.fetchThumbnails(ctx, user.PlexAuthToken, mappings)
 
 	// Render using templ template
-	if err := pages.MappingsDashboard(mappings, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript(), csrf.Token(r), sortOrder, searchQuery, printMode).Render(ctx, w); err != nil {
+	if err := pages.MappingsDashboard(mappings, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript(), sortOrder, searchQuery, printMode).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}
@@ -214,7 +213,7 @@ func (h *MappingsHandler) NewMappingForm(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Render using templ template
-	if err := pages.MappingsNewForm(NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript(), csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.MappingsNewForm(NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript()).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}
@@ -310,7 +309,7 @@ func (h *MappingsHandler) EditMappingForm(w http.ResponseWriter, r *http.Request
 	}
 
 	// Render using templ template
-	if err := pages.MappingsEditForm(mapping, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript(), csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.MappingsEditForm(mapping, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript()).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}

--- a/internal/handlers/media_detail.go
+++ b/internal/handlers/media_detail.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/plex"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
 	"github.com/go-chi/chi/v5"
-	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
 )
 
@@ -134,7 +133,7 @@ func (h *MediaDetailHandler) Detail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Render using templ template
-	if err := pages.MediaDetail(metadata.Title, metadata.Type, metadata.Summary, metadata.Year, thumbnailURL, plexWebURL, serverID, ratingKey, serverName, defaultAppleTV, existingMapping != nil, h.appleTVs, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript(), csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.MediaDetail(metadata.Title, metadata.Type, metadata.Summary, metadata.Year, thumbnailURL, plexWebURL, serverID, ratingKey, serverName, defaultAppleTV, existingMapping != nil, h.appleTVs, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript()).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/db"
 	"github.com/Chuntttttt/tapedeck/internal/middleware"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
-	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
 )
 
@@ -59,7 +58,7 @@ func (h *SettingsHandler) Settings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Render using templ template
-	if err := pages.Settings(runtimeCfg.PlexServers, runtimeCfg.HomeAssistant.URL, settings.HAToken, runtimeCfg.AppleTVs, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript(), csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.Settings(runtimeCfg.PlexServers, runtimeCfg.HomeAssistant.URL, settings.HAToken, runtimeCfg.AppleTVs, NavigationHTML(), ConnectionBannerHTML(), ConnectionBannerScript()).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}

--- a/internal/handlers/setup.go
+++ b/internal/handlers/setup.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/models"
 	"github.com/Chuntttttt/tapedeck/internal/plex"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
-	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
 )
 
@@ -193,7 +192,7 @@ func (h *SetupHandler) renderServerSelection(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 	log := middleware.GetLogger(ctx)
 
-	if err := pages.SetupServerSelection(servers, csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.SetupServerSelection(servers).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}
@@ -295,7 +294,7 @@ func (h *SetupHandler) Step3HomeAssistant(w http.ResponseWriter, r *http.Request
 	haURL := state.HAConfig.URL
 	haToken := state.HAToken
 
-	if err := pages.SetupHomeAssistant(haURL, haToken, csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.SetupHomeAssistant(haURL, haToken).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}
@@ -435,7 +434,7 @@ func (h *SetupHandler) renderAppleTVSelection(w http.ResponseWriter, r *http.Req
 	ctx := r.Context()
 	log := middleware.GetLogger(ctx)
 
-	if err := pages.SetupAppleTVSelection(mediaPlayers, state.SelectedTVs, csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.SetupAppleTVSelection(mediaPlayers, state.SelectedTVs).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}
@@ -543,7 +542,7 @@ func (h *SetupHandler) Step5Complete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := pages.SetupComplete(len(state.PlexServers), state.HAConfig.URL, len(state.AppleTVs), csrf.Token(r)).Render(ctx, w); err != nil {
+	if err := pages.SetupComplete(len(state.PlexServers), state.HAConfig.URL, len(state.AppleTVs)).Render(ctx, w); err != nil {
 		log.Error("Failed to render template", "error", err)
 		RespondError(w, r, "Failed to render page", http.StatusInternalServerError)
 	}

--- a/main.go
+++ b/main.go
@@ -23,53 +23,7 @@ import (
 	"github.com/Chuntttttt/tapedeck/internal/router"
 	"github.com/Chuntttttt/tapedeck/internal/services"
 	"github.com/Chuntttttt/tapedeck/templates/pages"
-	"github.com/gorilla/csrf"
 )
-
-// csrfExemptMiddleware wraps CSRF protection but exempts certain routes
-// that don't use HTML forms (API endpoints use JSON, WebSocket endpoints use WS protocol)
-func csrfExemptMiddleware(csrfProtect func(http.Handler) http.Handler, devMode bool) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Exempt API routes (use JSON, not forms)
-			if strings.HasPrefix(r.URL.Path, "/api/") {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			// Exempt WebSocket routes (use WS protocol, not forms)
-			if strings.HasPrefix(r.URL.Path, "/ws/") {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			// Exempt metrics endpoint (Prometheus scraping)
-			if r.URL.Path == "/metrics" {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			// Exempt health check endpoint
-			if r.URL.Path == "/health" {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			// In dev mode, exempt localhost cross-origin requests (for Air proxy)
-			if devMode && r.Method != "GET" && r.Method != "HEAD" {
-				origin := r.Header.Get("Origin")
-				if origin != "" && (strings.HasPrefix(origin, "http://localhost:") || strings.HasPrefix(origin, "http://127.0.0.1:")) {
-					// Localhost origin in dev mode - skip CSRF check
-					next.ServeHTTP(w, r)
-					return
-				}
-			}
-
-			// Apply CSRF protection to all other routes
-			csrfProtect(next).ServeHTTP(w, r)
-		})
-	}
-}
 
 func main() {
 	// Try to load runtime configuration from config.yml
@@ -345,46 +299,50 @@ func main() {
 	// Create router
 	r := router.New(deps)
 
-	// Configure CSRF protection
-	// Exempt API and WebSocket routes (they use JSON/WebSocket, not forms)
-	csrfOptions := []csrf.Option{
-		csrf.Secure(cfg.RequireTLS),
-		csrf.Path("/"),
-		csrf.SameSite(csrf.SameSiteLaxMode),
-		csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger.Warn("CSRF validation failed",
-				"path", r.URL.Path,
-				"method", r.Method,
-				"remote_addr", r.RemoteAddr,
-				"origin", r.Header.Get("Origin"),
-				"host", r.Host,
-				"reason", csrf.FailureReason(r))
+	// Configure CSRF protection using Go 1.25 standard library
+	// CrossOriginProtection uses Fetch metadata headers (no tokens/cookies)
+	csrfProtection := http.NewCrossOriginProtection()
 
-			// Render proper error page
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.WriteHeader(http.StatusForbidden)
-			if err := pages.Error(http.StatusForbidden, "CSRF token validation failed. Please try again.").Render(r.Context(), w); err != nil {
-				logger.Error("Failed to render CSRF error page", "error", err)
-				http.Error(w, "CSRF token validation failed", http.StatusForbidden)
-			}
-		})),
-	}
+	// Set custom error handler
+	csrfProtection.SetDenyHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger.Warn("CSRF validation failed",
+			"path", r.URL.Path,
+			"method", r.Method,
+			"remote_addr", r.RemoteAddr,
+			"origin", r.Header.Get("Origin"),
+			"host", r.Host)
 
-	csrfMiddleware := csrf.Protect(cfg.CSRFKey, csrfOptions...)
+		// Render proper error page
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusForbidden)
+		if err := pages.Error(http.StatusForbidden, "CSRF validation failed. Please try again.").Render(r.Context(), w); err != nil {
+			logger.Error("Failed to render CSRF error page", "error", err)
+			http.Error(w, "CSRF validation failed", http.StatusForbidden)
+		}
+	}))
 
+	// Exempt routes that don't use HTML forms
+	csrfProtection.AddInsecureBypassPattern("/api/")    // API routes use JSON
+	csrfProtection.AddInsecureBypassPattern("/ws/")     // WebSocket routes
+	csrfProtection.AddInsecureBypassPattern("/metrics") // Prometheus scraping
+	csrfProtection.AddInsecureBypassPattern("/health")  // Health check
+
+	// In dev mode, allow localhost cross-origin requests (for Air proxy)
 	if cfg.DevMode {
+		csrfProtection.AddInsecureBypassPattern("http://localhost:")
+		csrfProtection.AddInsecureBypassPattern("http://127.0.0.1:")
 		logger.Info("CSRF protection: allowing localhost cross-origin requests in dev mode")
 	}
 
 	// Wrap with middleware chain
-	// 1. CSRF protection (validates tokens on POST/PUT/PATCH/DELETE)
+	// 1. CSRF protection (validates cross-origin requests using Fetch metadata)
 	// 2. Metrics middleware (tracks request metrics)
 	// 3. Request ID middleware (generates unique request ID)
 	// 4. User ID middleware (extracts user ID from session)
 	// 5. Request logger middleware (creates scoped logger with request metadata)
 	// 6. Request logging middleware (logs all requests)
 	// 7. Setup middleware (checks config for all non-exempted routes)
-	handler := csrfExemptMiddleware(csrfMiddleware, cfg.DevMode)(
+	handler := csrfProtection.Handler(
 		middleware.MetricsMiddleware()(
 			middleware.WithRequestID()(
 				middleware.WithUserID(sessionStore)(

--- a/templates/pages/mappings_dashboard.templ
+++ b/templates/pages/mappings_dashboard.templ
@@ -5,11 +5,11 @@ import "github.com/Chuntttttt/tapedeck/internal/models"
 import "fmt"
 
 // MappingsDashboard renders the card mappings dashboard
-templ MappingsDashboard(mappings []*models.CardMapping, navHTML string, bannerHTML string, bannerScript string, csrfToken string, sortOrder string, searchQuery string, printMode bool) {
-	@layouts.AppLayout("Card Mappings", navHTML, bannerHTML, bannerScript, dashboardContent(mappings, csrfToken, sortOrder, searchQuery, printMode))
+templ MappingsDashboard(mappings []*models.CardMapping, navHTML string, bannerHTML string, bannerScript string, sortOrder string, searchQuery string, printMode bool) {
+	@layouts.AppLayout("Card Mappings", navHTML, bannerHTML, bannerScript, dashboardContent(mappings, sortOrder, searchQuery, printMode))
 }
 
-templ dashboardContent(mappings []*models.CardMapping, csrfToken string, sortOrder string, searchQuery string, printMode bool) {
+templ dashboardContent(mappings []*models.CardMapping, sortOrder string, searchQuery string, printMode bool) {
 	<div class="app-page">
 		<div class="header">
 			<h1>My Card Collection</h1>
@@ -52,7 +52,6 @@ templ dashboardContent(mappings []*models.CardMapping, csrfToken string, sortOrd
 		</div>
 		if printMode {
 			<form id="print-form" method="POST" action="/mappings/generate-stickers">
-				<input type="hidden" name="csrf_token" value={ csrfToken }/>
 				<div style="margin-bottom: 1rem; display: flex; gap: 1rem;">
 					<button type="button" id="select-all" class="btn" style="background: #6b7280;">Select All</button>
 					<button type="button" id="deselect-all" class="btn" style="background: #6b7280;">Deselect All</button>

--- a/templates/pages/mappings_edit.templ
+++ b/templates/pages/mappings_edit.templ
@@ -5,15 +5,14 @@ import "github.com/Chuntttttt/tapedeck/internal/models"
 import "fmt"
 
 // MappingsEditForm renders the edit mapping form page
-templ MappingsEditForm(mapping *models.CardMapping, navHTML string, bannerHTML string, bannerScript string, csrfToken string) {
-	@layouts.AppLayout("Edit Card Mapping", navHTML, bannerHTML, bannerScript, editFormContent(mapping, csrfToken))
+templ MappingsEditForm(mapping *models.CardMapping, navHTML string, bannerHTML string, bannerScript string) {
+	@layouts.AppLayout("Edit Card Mapping", navHTML, bannerHTML, bannerScript, editFormContent(mapping))
 }
 
-templ editFormContent(mapping *models.CardMapping, csrfToken string) {
+templ editFormContent(mapping *models.CardMapping) {
 	<div class="app-page-narrow">
 		<h1>Edit Card Mapping</h1>
 		<form method="post" action={ templ.SafeURL(fmt.Sprintf("/mappings/%d", mapping.ID)) }>
-			<input type="hidden" name="gorilla.csrf.Token" value={ csrfToken }/>
 			<div class="form-group">
 				<label for="tag_id">NFC Tag ID *</label>
 				<input type="text" id="tag_id" name="tag_id" value={ mapping.TagID } required placeholder="e.g., nfc-12345"/>

--- a/templates/pages/mappings_new.templ
+++ b/templates/pages/mappings_new.templ
@@ -4,15 +4,14 @@ import "github.com/Chuntttttt/tapedeck/templates/layouts"
 import "github.com/Chuntttttt/tapedeck/templates/components"
 
 // MappingsNewForm renders the new mapping form page
-templ MappingsNewForm(navHTML string, bannerHTML string, bannerScript string, csrfToken string) {
-	@layouts.AppLayout("New Card Mapping", navHTML, bannerHTML, bannerScript, newFormContent(csrfToken))
+templ MappingsNewForm(navHTML string, bannerHTML string, bannerScript string) {
+	@layouts.AppLayout("New Card Mapping", navHTML, bannerHTML, bannerScript, newFormContent())
 }
 
-templ newFormContent(csrfToken string) {
+templ newFormContent() {
 	<div class="app-page-narrow">
 		<h1>Create New Card Mapping</h1>
 		<form method="post" action="/mappings" id="mappingForm">
-			<input type="hidden" name="gorilla.csrf.Token" value={ csrfToken }/>
 			<div class="form-group">
 				<label for="tag_id">NFC Tag ID *</label>
 				<input type="text" id="tag_id" name="tag_id" required placeholder="e.g., nfc-12345"/>

--- a/templates/pages/media_detail.templ
+++ b/templates/pages/media_detail.templ
@@ -5,11 +5,11 @@ import "github.com/Chuntttttt/tapedeck/internal/config"
 import "fmt"
 
 // MediaDetail renders the media detail page
-templ MediaDetail(title string, mediaType string, summary string, year int, thumbnailURL string, plexWebURL string, serverID string, ratingKey string, serverName string, defaultAppleTV string, isPaired bool, appleTVs []config.AppleTV, navHTML string, bannerHTML string, bannerScript string, csrfToken string) {
-	@layouts.AppLayout(title, navHTML, bannerHTML, bannerScript, mediaDetailContent(title, mediaType, summary, year, thumbnailURL, plexWebURL, serverID, ratingKey, serverName, defaultAppleTV, isPaired, appleTVs, csrfToken))
+templ MediaDetail(title string, mediaType string, summary string, year int, thumbnailURL string, plexWebURL string, serverID string, ratingKey string, serverName string, defaultAppleTV string, isPaired bool, appleTVs []config.AppleTV, navHTML string, bannerHTML string, bannerScript string) {
+	@layouts.AppLayout(title, navHTML, bannerHTML, bannerScript, mediaDetailContent(title, mediaType, summary, year, thumbnailURL, plexWebURL, serverID, ratingKey, serverName, defaultAppleTV, isPaired, appleTVs))
 }
 
-templ mediaDetailContent(title string, mediaType string, summary string, year int, thumbnailURL string, plexWebURL string, serverID string, ratingKey string, serverName string, defaultAppleTV string, isPaired bool, appleTVs []config.AppleTV, csrfToken string) {
+templ mediaDetailContent(title string, mediaType string, summary string, year int, thumbnailURL string, plexWebURL string, serverID string, ratingKey string, serverName string, defaultAppleTV string, isPaired bool, appleTVs []config.AppleTV) {
 	<div class="media-detail">
 		<div class="media-detail-container">
 			<div class="media-poster-column">

--- a/templates/pages/settings.templ
+++ b/templates/pages/settings.templ
@@ -4,11 +4,11 @@ import "github.com/Chuntttttt/tapedeck/templates/layouts"
 import "github.com/Chuntttttt/tapedeck/internal/config"
 
 // Settings renders the settings page
-templ Settings(plexServers []config.PlexServer, haURL string, haToken string, appleTVs []config.AppleTV, navHTML string, bannerHTML string, bannerScript string, csrfToken string) {
-	@layouts.AppLayout("Settings", navHTML, bannerHTML, bannerScript, settingsContent(plexServers, haURL, haToken, appleTVs, csrfToken))
+templ Settings(plexServers []config.PlexServer, haURL string, haToken string, appleTVs []config.AppleTV, navHTML string, bannerHTML string, bannerScript string) {
+	@layouts.AppLayout("Settings", navHTML, bannerHTML, bannerScript, settingsContent(plexServers, haURL, haToken, appleTVs))
 }
 
-templ settingsContent(plexServers []config.PlexServer, haURL string, haToken string, appleTVs []config.AppleTV, csrfToken string) {
+templ settingsContent(plexServers []config.PlexServer, haURL string, haToken string, appleTVs []config.AppleTV) {
 	<style>
 		.settings-section {
 			background: var(--bg-container);
@@ -129,7 +129,6 @@ templ settingsContent(plexServers []config.PlexServer, haURL string, haToken str
 			<h1>⚙️ Settings</h1>
 		</div>
 		<form method="post" action="/settings/servers">
-			<input type="hidden" name="gorilla.csrf.Token" value={ csrfToken }/>
 			<div class="settings-section">
 				<h2 class="settings-heading">Plex Servers</h2>
 				if len(plexServers) == 0 {

--- a/templates/pages/setup_appletv_selection.templ
+++ b/templates/pages/setup_appletv_selection.templ
@@ -6,11 +6,11 @@ import "github.com/Chuntttttt/tapedeck/internal/ha"
 import "fmt"
 
 // SetupAppleTVSelection renders the Apple TV selection page
-templ SetupAppleTVSelection(mediaPlayers []ha.Entity, selectedTVs map[string]bool, csrfToken string) {
-	@layouts.SetupLayout("Select Apple TVs", 4, appleTVSelectionContent(mediaPlayers, selectedTVs, csrfToken))
+templ SetupAppleTVSelection(mediaPlayers []ha.Entity, selectedTVs map[string]bool) {
+	@layouts.SetupLayout("Select Apple TVs", 4, appleTVSelectionContent(mediaPlayers, selectedTVs))
 }
 
-templ appleTVSelectionContent(mediaPlayers []ha.Entity, selectedTVs map[string]bool, csrfToken string) {
+templ appleTVSelectionContent(mediaPlayers []ha.Entity, selectedTVs map[string]bool) {
 	<style>
 		.setup-tv-list {
 			display: flex;
@@ -56,7 +56,6 @@ templ appleTVSelectionContent(mediaPlayers []ha.Entity, selectedTVs map[string]b
 		<h1>Select Apple TVs</h1>
 		<p style="color: var(--text-secondary);">We found { fmt.Sprintf("%d", len(mediaPlayers)) } media player(s) in Home Assistant. Select which ones you'd like to use with TapeDeck.</p>
 		<form method="post" action="/setup/appletv/save">
-			<input type="hidden" name="gorilla.csrf.Token" value={ csrfToken }/>
 			<div class="setup-tv-list">
 				for _, player := range mediaPlayers {
 					@appleTVItem(player, len(mediaPlayers) == 1 || selectedTVs[player.EntityID])

--- a/templates/pages/setup_complete.templ
+++ b/templates/pages/setup_complete.templ
@@ -5,11 +5,11 @@ import "github.com/Chuntttttt/tapedeck/templates/components"
 import "fmt"
 
 // SetupComplete renders the setup completion page
-templ SetupComplete(numServers int, haURL string, numAppleTVs int, csrfToken string) {
-	@layouts.SetupLayout("Complete Setup", 4, completeContent(numServers, haURL, numAppleTVs, csrfToken))
+templ SetupComplete(numServers int, haURL string, numAppleTVs int) {
+	@layouts.SetupLayout("Complete Setup", 4, completeContent(numServers, haURL, numAppleTVs))
 }
 
-templ completeContent(numServers int, haURL string, numAppleTVs int, csrfToken string) {
+templ completeContent(numServers int, haURL string, numAppleTVs int) {
 	<div class="container">
 		@components.BackLink("/setup/appletv", "Back")
 		<div class="emoji">✓</div>
@@ -31,7 +31,6 @@ templ completeContent(numServers int, haURL string, numAppleTVs int, csrfToken s
 		</div>
 		<p>You're ready to start pairing NFC cards with your media!</p>
 		<form method="post" action="/setup/finish">
-			<input type="hidden" name="gorilla.csrf.Token" value={ csrfToken }/>
 			<button type="submit" class="btn">Start Using TapeDeck</button>
 		</form>
 	</div>

--- a/templates/pages/setup_home_assistant.templ
+++ b/templates/pages/setup_home_assistant.templ
@@ -4,18 +4,17 @@ import "github.com/Chuntttttt/tapedeck/templates/layouts"
 import "github.com/Chuntttttt/tapedeck/templates/components"
 
 // SetupHomeAssistant renders the Home Assistant configuration page
-templ SetupHomeAssistant(haURL string, haToken string, csrfToken string) {
-	@layouts.SetupLayout("Connect Home Assistant", 3, haContent(haURL, haToken, csrfToken))
+templ SetupHomeAssistant(haURL string, haToken string) {
+	@layouts.SetupLayout("Connect Home Assistant", 3, haContent(haURL, haToken))
 }
 
-templ haContent(haURL string, haToken string, csrfToken string) {
+templ haContent(haURL string, haToken string) {
 	<div class="container">
 		@components.BackLink("/setup/plex", "Back")
 		<h1>Connect Home Assistant</h1>
 		<p>Home Assistant controls playback on your Apple TV.</p>
 		<div id="status" class="status"></div>
 		<form method="post" action="/setup/ha/save" id="haForm">
-			<input type="hidden" name="gorilla.csrf.Token" value={ csrfToken }/>
 			<div class="form-group">
 				<label for="ha_url">Home Assistant URL *</label>
 				<input type="text" id="ha_url" name="ha_url" value={ haURL } required placeholder="http://homeassistant.local:8123"/>

--- a/templates/pages/setup_server_selection.templ
+++ b/templates/pages/setup_server_selection.templ
@@ -6,11 +6,11 @@ import "github.com/Chuntttttt/tapedeck/internal/config"
 import "fmt"
 
 // SetupServerSelection renders the server selection page
-templ SetupServerSelection(servers []config.PlexServer, csrfToken string) {
-	@layouts.SetupLayout("Select Plex Servers", 2, serverSelectionContent(servers, csrfToken))
+templ SetupServerSelection(servers []config.PlexServer) {
+	@layouts.SetupLayout("Select Plex Servers", 2, serverSelectionContent(servers))
 }
 
-templ serverSelectionContent(servers []config.PlexServer, csrfToken string) {
+templ serverSelectionContent(servers []config.PlexServer) {
 	<style>
 		.setup-server-list {
 			display: flex;
@@ -76,7 +76,6 @@ templ serverSelectionContent(servers []config.PlexServer, csrfToken string) {
 		<h1>Select Plex Servers</h1>
 		<p>We found { fmt.Sprintf("%d", len(servers)) } server(s) connected to your account. Select which servers you'd like to use with TapeDeck.</p>
 		<form method="post" action="/setup/plex/save" id="serverForm">
-			<input type="hidden" name="gorilla.csrf.Token" value={ csrfToken }/>
 			<div class="setup-server-list">
 				for _, server := range servers {
 					@serverItem(server)


### PR DESCRIPTION
## Summary
- Fixes Dependabot security alert for CVE-2025-47909 (gorilla/csrf vulnerability)
- Replaces token-based CSRF protection with Go 1.25 standard library `net/http.CrossOriginProtection`
- Uses Fetch metadata headers (Sec-Fetch-Site, Origin) instead of hidden form tokens

## Changes
- Replaced CSRF middleware in main.go with `CrossOriginProtection`
- Removed all `csrf.Token(r)` calls from handlers
- Removed `csrfToken` parameters from all templates
- Removed hidden CSRF token input fields from forms
- Removed `gorilla/csrf` dependency from go.mod

## Test plan
- [x] All tests pass (`go test -v -race ./...`)
- [x] No linting issues (`golangci-lint run`)
- [x] Code formatted (`go fmt ./...`)
- [x] 16 files changed, 68 insertions(+), 125 deletions(-)