### PR TITLE
Add DATA_DIR configuration for consolidating generated files.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,22 @@
 #
 # All settings are optional and have sensible defaults:
 # - PORT: 3001
-# - DATABASE_PATH: ./data/tapedeck.db
+# - DATA_DIR: . (current directory)
 # - LOG_LEVEL: info
 # - DEV_MODE: false
 # - REQUIRE_TLS: false
 #
-# Session secret is auto-generated on first run and stored in .session_secret
+# Session secret, CSRF key, and encryption key are auto-generated on first run
+# and stored in DATA_DIR (.session_secret, .csrf_key, .encryption_key)
+#
+# Database is stored in DATA_DIR/data/tapedeck.db
 #
 # Plex servers, Home Assistant, and Apple TVs are configured via the
 # web-based setup wizard (creates config.yml).
 
 # Uncomment to override defaults:
 # PORT=3001
-# DATABASE_PATH=./data/tapedeck.db
+# DATA_DIR=.
 # LOG_LEVEL=info
 # DEV_MODE=true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,12 @@ docker-compose logs -f tapedeck
 - Handlers are nil at startup if config.yml is missing; initialized after setup wizard completes via `initializeHandlers()` callback
 
 ### Configuration System
-- Environment variables (`.env`): Optional overrides for basic settings (PORT, DATABASE_PATH, LOG_LEVEL, DEV_MODE, REQUIRE_TLS). All have sensible defaults.
-- Session secret (`.session_secret`): Auto-generated on first run, persists across restarts (gitignored, 0600 permissions)
-- Encryption key (`.encryption_key`): AES-256 key auto-generated on first run for encrypting sensitive data (gitignored, 0600 permissions)
+- Environment variables (`.env`): Optional overrides for basic settings (PORT, DATA_DIR, LOG_LEVEL, DEV_MODE, REQUIRE_TLS). All have sensible defaults.
+- Data directory (`DATA_DIR`): All generated files stored here (defaults to `.`). Contains:
+  - Session secret (`.session_secret`): Auto-generated on first run (gitignored, 0600 permissions)
+  - CSRF key (`.csrf_key`): Auto-generated on first run (gitignored, 0600 permissions)
+  - Encryption key (`.encryption_key`): AES-256 key auto-generated on first run (gitignored, 0600 permissions)
+  - Database (`data/tapedeck.db`): SQLite database with encrypted tokens
 - Runtime config (`config.yml`): Plex servers, Home Assistant URL, Apple TVs (created by setup wizard)
 - **Security**: Plex auth tokens and Home Assistant token are encrypted at rest using AES-256-GCM (stored in database, not config.yml)
 - Setup wizard creates config.yml and triggers handler initialization

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ go mod download
 
 # Optional: Create .env file to override defaults
 # cp .env.example .env
-# Edit .env to customize PORT, DATABASE_PATH, LOG_LEVEL, or DEV_MODE
+# Edit .env to customize PORT, DATA_DIR, LOG_LEVEL, or DEV_MODE
 ```
 
 ### 3. Run Development Server
@@ -198,15 +198,16 @@ Application settings can be configured via environment variables (`.env` file). 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
 | `PORT` | HTTP server port | `3001` | `3001` |
-| `DATABASE_PATH` | SQLite database location | `./data/tapedeck.db` | `./data/tapedeck.db` |
+| `DATA_DIR` | Directory for generated files | `.` | `/path/to/data` |
 | `LOG_LEVEL` | Logging level | `info` | `info`, `debug`, `warn`, `error` |
 | `DEV_MODE` | Skip TLS verification (dev only) | `false` | `true` |
 | `REQUIRE_TLS` | Require HTTPS for session cookies | `false` | `true` |
 
-**Security**: Sensitive data is protected through encryption:
-- **Session Security**: Session encryption key auto-generated on first run, stored in `.session_secret` (gitignored)
-- **Token Encryption**: AES-256-GCM encryption key auto-generated on first run, stored in `.encryption_key` (gitignored)
-- **Encrypted Data**: Plex auth tokens and Home Assistant token are encrypted at rest in the database
+**Data Storage**: All generated files are stored in `DATA_DIR` (defaults to current directory):
+- **Session Security**: `.session_secret` - Session encryption key auto-generated on first run (gitignored, 0600 permissions)
+- **CSRF Protection**: `.csrf_key` - CSRF token key auto-generated on first run (gitignored, 0600 permissions)
+- **Token Encryption**: `.encryption_key` - AES-256-GCM key auto-generated on first run (gitignored, 0600 permissions)
+- **Database**: `data/tapedeck.db` - SQLite database with encrypted tokens
 
 ### Runtime Configuration (config.yml)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/joho/godotenv"
 )
@@ -15,13 +16,18 @@ import (
 // and loaded via LoadRuntimeConfig().
 type Config struct {
 	Port          string
-	DatabasePath  string
+	DataDir       string // Directory for all generated files (database, secrets)
 	LogLevel      string
 	SessionSecret string
 	CSRFKey       []byte // 32-byte key for CSRF protection
 	EncryptionKey []byte // 32-byte key for AES-256-GCM encryption
 	DevMode       bool
 	RequireTLS    bool
+}
+
+// DatabasePath returns the full path to the database file
+func (c *Config) DatabasePath() string {
+	return filepath.Join(c.DataDir, "data", "tapedeck.db")
 }
 
 // Load reads configuration from environment variables and validates required fields.
@@ -31,8 +37,11 @@ func Load() (*Config, error) {
 	// Try to load .env file (ignore error if it doesn't exist)
 	_ = godotenv.Load()
 
+	// Load data directory path from environment, default to current directory
+	dataDir := getEnvOrDefault("DATA_DIR", ".")
+
 	// Load session secret from persisted file, or generate and persist if missing
-	sessionSecret, err := loadSessionSecret()
+	sessionSecret, err := loadSessionSecret(dataDir)
 	if err == nil && sessionSecret != "" {
 		fmt.Println("Loaded SESSION_SECRET from .session_secret file")
 	} else {
@@ -43,7 +52,7 @@ func Load() (*Config, error) {
 		}
 
 		// Persist to file so sessions survive restarts
-		if err := saveSessionSecret(randomSecret); err != nil {
+		if err := saveSessionSecret(dataDir, randomSecret); err != nil {
 			return nil, fmt.Errorf("failed to persist SESSION_SECRET: %w", err)
 		}
 
@@ -52,7 +61,7 @@ func Load() (*Config, error) {
 	}
 
 	// Load CSRF key from persisted file, or generate and persist if missing
-	csrfKey, err := loadCSRFKey()
+	csrfKey, err := loadCSRFKey(dataDir)
 	if err == nil && len(csrfKey) == 32 {
 		fmt.Println("Loaded CSRF_KEY from .csrf_key file")
 	} else {
@@ -63,7 +72,7 @@ func Load() (*Config, error) {
 		}
 
 		// Persist to file so CSRF tokens remain valid after restarts
-		if err := saveCSRFKey(csrfKey); err != nil {
+		if err := saveCSRFKey(dataDir, csrfKey); err != nil {
 			return nil, fmt.Errorf("failed to persist CSRF_KEY: %w", err)
 		}
 
@@ -71,7 +80,7 @@ func Load() (*Config, error) {
 	}
 
 	// Load encryption key from persisted file, or generate and persist if missing
-	encryptionKey, err := loadEncryptionKey()
+	encryptionKey, err := loadEncryptionKey(dataDir)
 	if err == nil && len(encryptionKey) == 32 {
 		fmt.Println("Loaded ENCRYPTION_KEY from .encryption_key file")
 	} else {
@@ -82,7 +91,7 @@ func Load() (*Config, error) {
 		}
 
 		// Persist to file so encrypted data can be decrypted after restarts
-		if err := saveEncryptionKey(encryptionKey); err != nil {
+		if err := saveEncryptionKey(dataDir, encryptionKey); err != nil {
 			return nil, fmt.Errorf("failed to persist ENCRYPTION_KEY: %w", err)
 		}
 
@@ -91,7 +100,7 @@ func Load() (*Config, error) {
 
 	cfg := &Config{
 		Port:          getEnvOrDefault("PORT", "3001"),
-		DatabasePath:  getEnvOrDefault("DATABASE_PATH", "./data/tapedeck.db"),
+		DataDir:       dataDir,
 		LogLevel:      getEnvOrDefault("LOG_LEVEL", "info"),
 		SessionSecret: sessionSecret,
 		CSRFKey:       csrfKey,
@@ -113,8 +122,9 @@ func generateRandomSecret(bytes int) (string, error) {
 }
 
 // loadSessionSecret reads the session secret from .session_secret file
-func loadSessionSecret() (string, error) {
-	data, err := os.ReadFile(".session_secret")
+func loadSessionSecret(dataDir string) (string, error) {
+	path := filepath.Join(dataDir, ".session_secret")
+	data, err := os.ReadFile(path) //nolint:gosec // Path is constructed from config, not user input
 	if err != nil {
 		return "", err
 	}
@@ -122,14 +132,20 @@ func loadSessionSecret() (string, error) {
 }
 
 // saveSessionSecret writes the session secret to .session_secret file with restricted permissions
-func saveSessionSecret(secret string) error {
+func saveSessionSecret(dataDir, secret string) error {
+	// Ensure directory exists
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	path := filepath.Join(dataDir, ".session_secret")
 	// Write with 0600 permissions (owner read/write only)
-	return os.WriteFile(".session_secret", []byte(secret), 0600)
+	return os.WriteFile(path, []byte(secret), 0600)
 }
 
 // loadEncryptionKey reads the encryption key from .encryption_key file
-func loadEncryptionKey() ([]byte, error) {
-	data, err := os.ReadFile(".encryption_key")
+func loadEncryptionKey(dataDir string) ([]byte, error) {
+	path := filepath.Join(dataDir, ".encryption_key")
+	data, err := os.ReadFile(path) //nolint:gosec // Path is constructed from config, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -143,17 +159,23 @@ func loadEncryptionKey() ([]byte, error) {
 }
 
 // saveEncryptionKey writes the encryption key to .encryption_key file with restricted permissions
-func saveEncryptionKey(key []byte) error {
+func saveEncryptionKey(dataDir string, key []byte) error {
+	// Ensure directory exists
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	path := filepath.Join(dataDir, ".encryption_key")
 	// Encode to hex for readability
 	hexKey := make([]byte, hex.EncodedLen(len(key)))
 	hex.Encode(hexKey, key)
 	// Write with 0600 permissions (owner read/write only)
-	return os.WriteFile(".encryption_key", hexKey, 0600)
+	return os.WriteFile(path, hexKey, 0600)
 }
 
 // loadCSRFKey reads the CSRF key from .csrf_key file
-func loadCSRFKey() ([]byte, error) {
-	data, err := os.ReadFile(".csrf_key")
+func loadCSRFKey(dataDir string) ([]byte, error) {
+	path := filepath.Join(dataDir, ".csrf_key")
+	data, err := os.ReadFile(path) //nolint:gosec // Path is constructed from config, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -167,12 +189,17 @@ func loadCSRFKey() ([]byte, error) {
 }
 
 // saveCSRFKey writes the CSRF key to .csrf_key file with restricted permissions
-func saveCSRFKey(key []byte) error {
+func saveCSRFKey(dataDir string, key []byte) error {
+	// Ensure directory exists
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	path := filepath.Join(dataDir, ".csrf_key")
 	// Encode to hex for readability
 	hexKey := make([]byte, hex.EncodedLen(len(key)))
 	hex.Encode(hexKey, key)
 	// Write with 0600 permissions (owner read/write only)
-	return os.WriteFile(".csrf_key", hexKey, 0600)
+	return os.WriteFile(path, hexKey, 0600)
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,10 +8,10 @@ import (
 func TestLoad_Success(t *testing.T) {
 	// Set environment variables
 	setTestEnv(t, map[string]string{
-		"PORT":          "3001",
-		"DATABASE_PATH": "./test.db",
-		"LOG_LEVEL":     "info",
-		"DEV_MODE":      "true",
+		"PORT":      "3001",
+		"DATA_DIR":  "./testdata",
+		"LOG_LEVEL": "info",
+		"DEV_MODE":  "true",
 	})
 
 	cfg, err := Load()
@@ -22,8 +22,12 @@ func TestLoad_Success(t *testing.T) {
 	if cfg.Port != "3001" {
 		t.Errorf("Port = %q, want %q", cfg.Port, "3001")
 	}
-	if cfg.DatabasePath != "./test.db" {
-		t.Errorf("DatabasePath = %q, want %q", cfg.DatabasePath, "./test.db")
+	if cfg.DataDir != "./testdata" {
+		t.Errorf("DataDir = %q, want %q", cfg.DataDir, "./testdata")
+	}
+	// filepath.Join simplifies "./testdata" + "data" + "tapedeck.db" to "testdata/data/tapedeck.db"
+	if cfg.DatabasePath() != "testdata/data/tapedeck.db" {
+		t.Errorf("DatabasePath() = %q, want %q", cfg.DatabasePath(), "testdata/data/tapedeck.db")
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, "info")
@@ -60,7 +64,7 @@ func TestLoad_MissingSessionSecret(t *testing.T) {
 }
 
 func TestLoad_OptionalDefaults(t *testing.T) {
-	// Omit PORT, DATABASE_PATH, LOG_LEVEL, DEV_MODE to test defaults
+	// Omit PORT, DATA_DIR, LOG_LEVEL, DEV_MODE to test defaults
 	setTestEnv(t, map[string]string{})
 
 	cfg, err := Load()
@@ -71,8 +75,12 @@ func TestLoad_OptionalDefaults(t *testing.T) {
 	if cfg.Port != "3001" {
 		t.Errorf("Port default = %q, want %q", cfg.Port, "3001")
 	}
-	if cfg.DatabasePath != "./data/tapedeck.db" {
-		t.Errorf("DatabasePath default = %q, want %q", cfg.DatabasePath, "./data/tapedeck.db")
+	if cfg.DataDir != "." {
+		t.Errorf("DataDir default = %q, want %q", cfg.DataDir, ".")
+	}
+	// filepath.Join simplifies "." + "data" + "tapedeck.db" to "data/tapedeck.db"
+	if cfg.DatabasePath() != "data/tapedeck.db" {
+		t.Errorf("DatabasePath() default = %q, want %q", cfg.DatabasePath(), "data/tapedeck.db")
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("LogLevel default = %q, want %q", cfg.LogLevel, "info")
@@ -92,7 +100,7 @@ func setTestEnv(t *testing.T, envVars map[string]string) {
 
 	// Clear all relevant env vars first
 	allKeys := []string{
-		"PORT", "DATABASE_PATH", "LOG_LEVEL", "DEV_MODE",
+		"PORT", "DATA_DIR", "LOG_LEVEL", "DEV_MODE",
 	}
 	for _, key := range allKeys {
 		_ = os.Unsetenv(key)

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 	logger.Info("Starting TapeDeck", "log_level", cfg.LogLevel, "dev_mode", cfg.DevMode, "needs_setup", needsSetup)
 
 	// Initialize database with encryption key
-	database, err := db.New(cfg.DatabasePath, cfg.EncryptionKey)
+	database, err := db.New(cfg.DatabasePath(), cfg.EncryptionKey)
 	if err != nil {
 		log.Fatalf("Failed to initialize database: %v", err) //nolint:gocritic // exitAfterDefer: acceptable for fatal errors
 	}


### PR DESCRIPTION
- Add DataDir field to Config struct and remove DatabasePath field
- Add DatabasePath() method that derives path from DataDir
- Update all secret file functions to use DataDir parameter
- Create directories automatically when saving secret files
- Update tests to use DATA_DIR instead of DATABASE_PATH
- Database and secret files now stored in single configurable directory